### PR TITLE
[DEBUG] completer issue with RefComboBox

### DIFF
--- a/python/stack_of_tasks/ui/ref_tab/ref_details.py
+++ b/python/stack_of_tasks/ui/ref_tab/ref_details.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from PyQt5.QtWidgets import QCompleter
+
 from stack_of_tasks.ref_frame import JointFrame, Offset, RefFrame, World
 from stack_of_tasks.ui.data_input import DataInput
 from stack_of_tasks.ui.models import NumpyTableModel, RawDataRole, RefFramesModel
@@ -14,13 +16,18 @@ class Ref_Details(DataInput):
         self._matrix_model = NumpyTableModel()
 
         self._name = self.add_string_row("Name")
-        self._root = self.add_combo_row("Parent", combo=RefComboBox())
+        self._root = self.add_combo_row("Parent")
+        c = self._root.widget
+        c.setEditable(True)
+        c.setInsertPolicy(RefComboBox.NoInsert)
 
         self._transform = self.add_matrix_row("T", model=self._matrix_model)
 
     def set_model(self, model: RefFramesModel):
         self._refs_model = model
         self._root.widget.setModel(self._refs_model)
+        # BUG: setModel will make the completer unused!
+        self._root.widget.completer().setModel(model.allRefs())
 
     def _set_selection(self, obj):
         for i in range(self._refs_model.rowCount()):

--- a/python/stack_of_tasks/ui/ref_tab/ref_details.py
+++ b/python/stack_of_tasks/ui/ref_tab/ref_details.py
@@ -43,7 +43,6 @@ class Ref_Details(DataInput):
             self._transform.label.setText("Offset")
             self._transform.widget.setEnabled(True)
 
-            self._root.widget.setCurrentIndex(
-                self._root.widget.findData(ref.frame, RawDataRole)
-            )
+            idx = self._root.widget.findData(ref.frame, RawDataRole)
+            self._root.widget.setCurrentIndex(idx)
             self._root.setVisible(True)

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -3,7 +3,14 @@ import sys
 
 from PyQt5 import QtGui
 from PyQt5.QtCore import QModelIndex, QStringListModel, Qt, pyqtSlot
-from PyQt5.QtWidgets import QApplication, QComboBox, QLineEdit, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import (
+    QApplication,
+    QComboBox,
+    QCompleter,
+    QLineEdit,
+    QVBoxLayout,
+    QWidget,
+)
 
 from stack_of_tasks.ref_frame import JointFrame, World
 from stack_of_tasks.robot_model import RobotModel, RobotState
@@ -23,6 +30,7 @@ class Window(QWidget):
 
         lineedit = QLineEdit()
         lineedit.setCompleter(self.combo.completer())
+        self.combo.completer().setCompletionMode(QCompleter.PopupCompletion)
 
         lineedit.textChanged.connect(self.update_combo)
 


### PR DESCRIPTION
For some reason, the completer of RefComboBox stops working as soon as I call `setModel()`. However, this only happens in `run_gui.py`, not in `dev.py`. Let's ignore that issue for now.

Expected behavior: The completer should use the (extended) model passed.
Actual behavior: The completer stops working - no completion at all!
If not calling `setModel()` the completer works as expected but - naturally - just uses the model of the combo box.